### PR TITLE
Add exclusion of handler ts files in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 *.ts
+!lib/handlers/*.ts
 !*.d.ts
 
 # CDK asset staging directory


### PR DESCRIPTION
Add exclusion of the handler ts files to the npmignore so they are pushed as part of the package to npmjs. The ts files are built using esbuild or the docker container as part of the cdk deploy/synth commands.